### PR TITLE
Custom version tables

### DIFF
--- a/cmd/goose/cmd_create.go
+++ b/cmd/goose/cmd_create.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 var createCmd = &Command{

--- a/cmd/goose/cmd_create_integration_test.go
+++ b/cmd/goose/cmd_create_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/goose/cmd_dbversion.go
+++ b/cmd/goose/cmd_dbversion.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 var dbVersionCmd = &Command{

--- a/cmd/goose/cmd_down.go
+++ b/cmd/goose/cmd_down.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 var downCmd = &Command{

--- a/cmd/goose/cmd_redo.go
+++ b/cmd/goose/cmd_redo.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 var redoCmd = &Command{

--- a/cmd/goose/cmd_status.go
+++ b/cmd/goose/cmd_status.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 var statusCmd = &Command{
@@ -57,7 +57,7 @@ func statusRun(cmd *Command, args ...string) {
 
 func printMigrationStatus(db *sql.DB, version int64, script string) {
 	var row goose.Migration
-	q := fmt.Sprintf("SELECT tstamp, is_applied FROM goose_db_version WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", version)
+	q := fmt.Sprintf("SELECT tstamp, is_applied FROM %s WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", goose.TableName(), version)
 	e := db.QueryRow(q).Scan(&row.TStamp, &row.IsApplied)
 
 	if e != nil && e != sql.ErrNoRows {

--- a/cmd/goose/cmd_up.go
+++ b/cmd/goose/cmd_up.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 var upCmd = &Command{

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 // global options. available to any subcommands.

--- a/dbconf.yml
+++ b/dbconf.yml
@@ -1,0 +1,5 @@
+# An example DB conf using billing db for migrations and public.billing_db_version table for migration versioning
+local:
+  driver: postgres
+  open: user=postgres host=postgres dbname=billing sslmode=disable
+  versionTable: billing_db_version

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -95,8 +95,11 @@ func NewDBConf(dbDir, env string) (*DBConf, error) {
 	} else {
 		dbDir = filepath.Dir(cfgFile)
 
-		f, _ = yaml.ReadFile(cfgFile)
-
+		var err error
+		f, err = yaml.ReadFile(cfgFile)
+		if err != nil {
+			return nil, fmt.Errorf("error loading config file: %s", err)
+		}
 	}
 
 	migrationsDir := filepath.Join(dbDir, "migrations")

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -95,11 +95,8 @@ func NewDBConf(dbDir, env string) (*DBConf, error) {
 	} else {
 		dbDir = filepath.Dir(cfgFile)
 
-		var err error
-		f, err = yaml.ReadFile(cfgFile)
-		if err != nil {
-			return nil, fmt.Errorf("error loading config file: %s", err)
-		}
+		f, _ = yaml.ReadFile(cfgFile)
+
 	}
 
 	migrationsDir := filepath.Join(dbDir, "migrations")

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -32,6 +32,7 @@ driver: $DB_DRIVER
 import: $DB_DRIVER_IMPORT
 dialect: $DB_DIALECT
 open: $DB_DSN
+versionTable: $DB_VERSION_TABLE
 `
 
 // findDBConf looks for a dbconf.yaml file starting at the given directory and
@@ -122,6 +123,10 @@ func NewDBConf(dbDir, env string) (*DBConf, error) {
 	}
 
 	open, _ := confGet(f, env, "open")
+
+	if versionTable, err := confGet(f, env, "versionTable"); err == nil {
+		SetTableName(versionTable)
+	}
 
 	d := newDBDriver(drv, open)
 

--- a/lib/goose/dialect.go
+++ b/lib/goose/dialect.go
@@ -2,13 +2,14 @@ package goose
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 )
 
 // SqlDialect abstracts the details of specific SQL dialects
 // for goose's few SQL specific statements
 type SqlDialect interface {
-	createVersionTableSql() string // sql string to create the goose_db_version table
+	createVersionTableSql() string // sql string to create the db version table
 	insertVersionSql() string      // sql string to insert the initial version table row
 	dbVersionQuery(db *sql.DB) (*sql.Rows, error)
 }
@@ -36,21 +37,21 @@ func dialectByName(d string) SqlDialect {
 type PostgresDialect struct{}
 
 func (pg PostgresDialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
             	id serial NOT NULL,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`
+            );`, TableName())
 }
 
 func (pg PostgresDialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", TableName())
 }
 
 func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied, tstamp from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied, tstamp from %s ORDER BY id DESC", TableName()))
 
 	// XXX: check for postgres specific error indicating the table doesn't exist.
 	// for now, assume any error is because the table doesn't exist,
@@ -69,19 +70,19 @@ func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type RedshiftDialect struct{}
 
 func (pg RedshiftDialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
                 version_id       BIGINT    NOT NULL,
                 is_applied       BOOLEAN   NOT NULL,
                 tstamp           timestamp NOT NULL
-            ) SORTKEY(tstamp);`
+            ) SORTKEY(tstamp);`, TableName())
 }
 
 func (pg RedshiftDialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied, tstamp) VALUES ($1, $2, SYSDATE);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied, tstamp) VALUES ($1, $2, SYSDATE);", TableName())
 }
 
 func (pg RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied, tstamp from goose_db_version ORDER BY tstamp DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied, tstamp from %s ORDER BY tstamp DESC", TableName()))
 
 	// XXX: check for postgres specific error indicating the table doesn't exist.
 	// for now, assume any error is because the table doesn't exist,
@@ -100,21 +101,21 @@ func (pg RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type MySqlDialect struct{}
 
 func (m MySqlDialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
                 id serial NOT NULL,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`
+            );`, TableName())
 }
 
 func (m MySqlDialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", TableName())
 }
 
 func (m MySqlDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied, tstamp from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied, tstamp from %s ORDER BY id DESC", TableName()))
 
 	// XXX: check for mysql specific error indicating the table doesn't exist.
 	// for now, assume any error is because the table doesn't exist,
@@ -133,20 +134,20 @@ func (m MySqlDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type Sqlite3Dialect struct{}
 
 func (m Sqlite3Dialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 version_id INTEGER NOT NULL,
                 is_applied INTEGER NOT NULL,
                 tstamp TIMESTAMP DEFAULT (datetime('now'))
-            );`
+            );`, TableName())
 }
 
 func (m Sqlite3Dialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", TableName())
 }
 
 func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied, tstamp from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied, tstamp from %s ORDER BY id DESC", TableName()))
 
 	if err != nil && strings.Contains(err.Error(), "no such table") {
 		err = ErrTableDoesNotExist

--- a/lib/goose/migrate.go
+++ b/lib/goose/migrate.go
@@ -278,7 +278,7 @@ func EnsureDBVersion(conf *DBConf, db *sql.DB) (int64, error) {
 	panic("failure in EnsureDBVersion()")
 }
 
-// Create the goose_db_version table
+// Create the db version table
 // and insert the initial 0 value into it
 func createVersionTable(conf *DBConf, db *sql.DB) error {
 	txn, err := db.Begin()

--- a/lib/goose/templates.go
+++ b/lib/goose/templates.go
@@ -55,7 +55,7 @@ import (
 	"encoding/gob"
 
 	_ "{{.Import}}"
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 func main() {

--- a/lib/goose/templates/migration-main.go.tmpl
+++ b/lib/goose/templates/migration-main.go.tmpl
@@ -6,7 +6,7 @@ import (
 	"encoding/gob"
 
 	_ "{{.Import}}"
-	"github.com/CloudCom/goose/lib/goose"
+	"github.com/gogriddy/goose/lib/goose"
 )
 
 func main() {

--- a/lib/goose/version.go
+++ b/lib/goose/version.go
@@ -1,0 +1,13 @@
+package goose
+
+var tableName = "goose_db_version"
+
+// TableName returns goose db version table name
+func TableName() string {
+	return tableName
+}
+
+// SetTableName set goose db version table name
+func SetTableName(n string) {
+	tableName = n
+}


### PR DESCRIPTION
This should allow for migrations on one database with multiple schemas.

Multiple schemas in one database can exist, so `billing.*`, `tdsp.*`, `users.*`, etc.
Versioned migrations would then look like `billing_db_version`, `tdsp_db_version`, etc.

The reasoning behind this change is because some migrations require multiple database connections, `cost_calculator_work` being one of the repos that come to mind. If only one database connection needs to be made, automation of migrations are much more simpler to do than having to parse through the SQL file, splitting the file per database connection, then making each connection for its respective migration.

Not sure if this is an issue in production. Clarification would be fantastic!